### PR TITLE
Fix geolocation tracking by adding proper public ip address

### DIFF
--- a/lib/plausible_analytics.dart
+++ b/lib/plausible_analytics.dart
@@ -1,8 +1,9 @@
 library plausible_analytics;
 
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:universal_io/io.dart'; // instead of 'dart:io';
-import 'dart:convert';
 
 /// Plausible class. Use the constructor to set the parameters.
 class Plausible {
@@ -33,8 +34,8 @@ class Plausible {
       // Remove trailing slash '/'
       serverUrl = serverUrl.substring(0, lastCharIndex);
     }
-    page = "app://localhost/" + page;
-    referrer = "app://localhost/" + referrer;
+    page = "app://localhost/$page";
+    referrer = "app://localhost/$referrer";
 
     // Get and set device infos
     String version = Platform.operatingSystemVersion.replaceAll('"', '');
@@ -44,13 +45,14 @@ class Plausible {
     }
 
     // Http Post request see https://plausible.io/docs/events-api
+    HttpClient client = HttpClient();
     try {
-      HttpClient client = HttpClient();
       HttpClientRequest request =
-          await client.postUrl(Uri.parse(serverUrl + '/api/event'));
+          await client.postUrl(Uri.parse('$serverUrl/api/event'));
       request.headers.set('User-Agent', userAgent);
       request.headers.set('Content-Type', 'application/json; charset=utf-8');
-      request.headers.set('X-Forwarded-For', '127.0.0.1');
+      final ip = await getPublicIP();
+      request.headers.set('X-Forwarded-For', ip ?? '127.0.0.1');
       Object body = {
         "domain": domain,
         "name": name,
@@ -61,14 +63,49 @@ class Plausible {
       };
       request.write(json.encode(body));
       final HttpClientResponse response = await request.close();
-      client.close();
       return response.statusCode;
     } catch (e) {
       if (kDebugMode) {
         print(e);
       }
+    } finally {
+      client.close();
     }
 
     return 1;
+  }
+
+  Future<String?> getPublicIP() async {
+    HttpClient client = HttpClient();
+    try {
+      const url = 'https://api.ipify.org';
+
+      HttpClientRequest request = await client.getUrl(Uri.parse(url));
+      final HttpClientResponse response = await request.close();
+      final stringData = await response.transform(utf8.decoder).join();
+
+      if (response.statusCode == 200) {
+        // The response body is the IP in plain text, so just
+        // return it as-is.
+        return stringData;
+      } else {
+        // The request failed with a non-200 code
+        // The ipify.org API has a lot of guaranteed uptime
+        // promises, so this shouldn't ever actually happen.
+        if (kDebugMode) {
+          print('Couldn\'t get public API $stringData');
+        }
+      }
+    } catch (e) {
+      // Request failed due to an error, most likely because
+      // the phone isn't connected to the internet.
+      if (kDebugMode) {
+        print(e);
+      }
+      return null;
+    } finally {
+      client.close();
+    }
+    return null;
   }
 }


### PR DESCRIPTION
As far as I know, Flutter has no way of getting the public IP address of the device, which is needed for geolocation to work (map in plausible dashboard).
I used the most common API for that.